### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To help facilitate the simplest integration with your code base, the necessary m
 
   <!-- Panel method 2 -->
   <section data-atabs-panel>
-    <h# data-atabs-label>
+    <h# data-atabs-heading>
       <!-- 
         The text/markup injected the panel's 
         associated role="tab" element.


### PR DESCRIPTION
Typo in panel method 2 does not generate correct heading and reverts to default label, need to change `data-atabs-label` to `data-atabs-heading` to match the example. :)